### PR TITLE
Tweak account details grid style

### DIFF
--- a/dark.mode.css
+++ b/dark.mode.css
@@ -2917,6 +2917,7 @@ button {
 .fieldList_b69b77 {
     margin-left: 10px;
     margin-bottom: 25px;
+    grid-gap: 15px;
 }
 
 .field_b69b77:last-child {
@@ -2942,7 +2943,6 @@ div[class="field_b69b77"] > button[aria-label="Edit username"][class="fieldButto
 }
 
 .theme-dark .field_b69b77 {
-    width: calc((100% / 2.2) - ((-45 / 3) * 1px));
     border-radius: 8px;
     background-color: #333135;
     max-height: none;
@@ -2950,7 +2950,6 @@ div[class="field_b69b77"] > button[aria-label="Edit username"][class="fieldButto
     padding: 15px;
     display: inline-block;
     margin-right: 10px;
-    margin-top: 10px !important;
     position: relative;
     overflow-y: scroll;
     height: 150px;

--- a/light.mode.css
+++ b/light.mode.css
@@ -2817,6 +2817,7 @@ button {
 .fieldList_b69b77 {
     margin-left: 10px;
     margin-bottom: 25px;
+    grid-gap: 15px;
 }
 
 .field_b69b77:last-child {
@@ -2834,7 +2835,6 @@ div[class="field_b69b77"] > button[aria-label="Edit username"][class="fieldButto
 }
 
 .theme-light .field_b69b77 {
-    width: calc((100% / 2.2) - ((-45 / 3) * 1px));
     border-radius: 8px;
     background-color: #e4e4e4;
     max-height: none;
@@ -2842,7 +2842,6 @@ div[class="field_b69b77"] > button[aria-label="Edit username"][class="fieldButto
     padding: 15px;
     display: inline-block;
     margin-right: 10px;
-    margin-top: 10px !important;
     position: relative;
     overflow-y: scroll;
     height: 150px;


### PR DESCRIPTION
Let grid decide the width of children elements rather than calculating the width of each element ourselves.

# Before
![Capture](https://github.com/warrayquipsome/Chillax/assets/16233776/66f336ef-1d21-47ed-8952-b3d2386d27c9)
# After
![beforeChillax](https://github.com/warrayquipsome/Chillax/assets/16233776/a53bc20b-1ccc-4962-99d3-170820f59374)
